### PR TITLE
Removes the github dependency and switches to string field

### DIFF
--- a/lib/modules/products/index.js
+++ b/lib/modules/products/index.js
@@ -6,7 +6,7 @@ module.exports = {
   fields: {
     add: {
       price: {
-        type: 'float'
+        type: 'string'
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node app @apostrophecms/assets:build",
     "dev": "npm run build && npm start",
-    "start": "node app.js"
+    "start": "node app.js",
+    "storybook": "node app @apostrophecms/assets:build && node app @apostrophecms/storybook:run"
   },
   "repository": {
     "type": "git",
@@ -14,9 +15,6 @@
   },
   "author": "P'unk Avenue",
   "license": "MIT",
-  "dependencies": {
-    "apostrophe": "git://github.com/apostrophecms/apostrophe.git#3.0"
-  },
   "nodemonConfig": {
     "verbose": true,
     "ignore": [


### PR DESCRIPTION
The string field change is simply because that field type is more ready for use in testing.